### PR TITLE
Add board.render method

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -77,4 +77,14 @@ class Board
     end
   end
 
+  def render(show_ship = false)
+    "  1 2 3 4\n" +
+    "A #{cells["A1"].render(show_ship)} #{cells["A2"].render(show_ship)} #{cells["A3"].render(show_ship)} #{cells["A4"].render(show_ship)}\n" +
+    "B #{cells["B1"].render(show_ship)} #{cells["B2"].render(show_ship)} #{cells["B3"].render(show_ship)} #{cells["B4"].render(show_ship)}\n" +
+    "C #{cells["C1"].render(show_ship)} #{cells["C2"].render(show_ship)} #{cells["C3"].render(show_ship)} #{cells["C4"].render(show_ship)}\n" +
+    "D #{cells["D1"].render(show_ship)} #{cells["D2"].render(show_ship)} #{cells["D3"].render(show_ship)} #{cells["D4"].render(show_ship)}\n"
+
+    # to see the board in pry, use puts @board.render 
+  end
+
 end

--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -1,12 +1,12 @@
 class Cell
 
-  attr_reader :coordinates,
+  attr_reader :coordinate,
               :fired_upon
   attr_accessor :ship
 
 
-  def initialize(coordinates)
-    @coordinates = coordinates
+  def initialize(coordinate)
+    @coordinate = coordinate
     @ship = nil
     @fired_upon = false
   end

--- a/test/board_test.rb
+++ b/test/board_test.rb
@@ -107,28 +107,18 @@ class BoardTest < Minitest::Test
     assert_equal false, @board.valid_placement?(@submarine, ["A1", "B1"])
   end
 
-  # def test_it_has_default_rendered_state
-  #   skip
-  #   # board is rendered with no shots fired by default
-  #   assert_equal
-  #   "  1 2 3 4 \n" +
-  #   "A . . . . \n" +
-  #   "B . . . . \n" +
-  #   "C . . . . \n" +
-  #   "D . . . . \n" , @board.render
-  # end
-  #
-  # def test_it_renders_with_a_ship
-  #   skip
-  #   # board is rendered after a ship has been placed
-  #   # this is designated by the optional argument (true)
-  #   assert_equal
-  #   "  1 2 3 4 \n" +
-  #   "A S S S . \n" +
-  #   "B . . . . \n" +
-  #   "C . . . . \n" +
-  #   "D . . . . \n" , @board.render(true)
-  # end
+  def test_it_has_default_rendered_state
+    # skip
+    # board is rendered with no shots fired by default
+    assert_equal "  1 2 3 4\nA . . . .\nB . . . .\nC . . . .\nD . . . .\n" , @board.render
+  end
+
+  def test_it_renders_with_a_ship
+    # skip
+    @board.place(@cruiser, ["A1", "A2", "A3"])
+
+    assert_equal "  1 2 3 4\nA S S S .\nB . . . .\nC . . . .\nD . . . .\n" , @board.render(true)
+  end
 
   # ADD MORE RENDERING TESTS HERE
   # include board rendering with Hits, Misses,


### PR DESCRIPTION
@amymoller 
All tests pass so far for default rendering, and rendering with ships.
Need to add tests for rendering other types of cells (H, M, X)

To see the board in the terminal, run pry and use `puts`. 
For example, `puts @board.render`